### PR TITLE
Use SHA256 and SHA1 directly from BC

### DIFF
--- a/certificatetransparency/src/main/kotlin/com/babylon/certificatetransparency/internal/utils/CertificateExt.kt
+++ b/certificatetransparency/src/main/kotlin/com/babylon/certificatetransparency/internal/utils/CertificateExt.kt
@@ -67,9 +67,6 @@ internal fun Certificate.hasEmbeddedSct(): Boolean {
 // not PreCertificate Signing Cert. In this case, the only thing that's needed is the
 // issuer key hash - the Precertificate will already have the right value for the issuer
 // name and K509 Authority Key Identifier extension.
-/**
- * @throws NoSuchAlgorithmException
- */
 internal fun Certificate.issuerInformation(): IssuerInformation {
     return IssuerInformation(keyHash = keyHash(), issuedByPreCertificateSigningCert = false)
 }
@@ -90,7 +87,4 @@ internal fun Certificate.issuerInformationFromPreCertificate(preCertificate: Cer
     }
 }
 
-/**
- * @throws NoSuchAlgorithmException
- */
 private fun Certificate.keyHash() = publicKey.sha256Hash()

--- a/certificatetransparency/src/main/kotlin/com/babylon/certificatetransparency/internal/utils/PublicKeyExt.kt
+++ b/certificatetransparency/src/main/kotlin/com/babylon/certificatetransparency/internal/utils/PublicKeyExt.kt
@@ -22,15 +22,8 @@ package com.babylon.certificatetransparency.internal.utils
 
 import org.bouncycastle.jcajce.provider.digest.SHA1
 import org.bouncycastle.jcajce.provider.digest.SHA256
-import java.security.NoSuchAlgorithmException
 import java.security.PublicKey
 
-/**
- * @throws NoSuchAlgorithmException
- */
 internal fun PublicKey.sha256Hash(): ByteArray = SHA256.Digest().digest(encoded)
 
-/**
- * @throws NoSuchAlgorithmException
- */
 internal fun PublicKey.sha1Hash(): ByteArray = SHA1.Digest().digest(encoded)

--- a/certificatetransparency/src/main/kotlin/com/babylon/certificatetransparency/internal/utils/PublicKeyExt.kt
+++ b/certificatetransparency/src/main/kotlin/com/babylon/certificatetransparency/internal/utils/PublicKeyExt.kt
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2021 Appmattus Limited
  * Copyright 2019 Babylon Partners Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,20 +13,24 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * File modified by Appmattus Limited
+ * See: https://github.com/appmattus/certificatetransparency/compare/e3d469df9be35bcbf0f564d32ca74af4e5ca4ae5...main
  */
 
 package com.babylon.certificatetransparency.internal.utils
 
-import java.security.MessageDigest
+import org.bouncycastle.jcajce.provider.digest.SHA1
+import org.bouncycastle.jcajce.provider.digest.SHA256
 import java.security.NoSuchAlgorithmException
 import java.security.PublicKey
 
 /**
  * @throws NoSuchAlgorithmException
  */
-internal fun PublicKey.sha256Hash(): ByteArray = MessageDigest.getInstance("SHA-256").digest(encoded)
+internal fun PublicKey.sha256Hash(): ByteArray = SHA256.Digest().digest(encoded)
 
 /**
  * @throws NoSuchAlgorithmException
  */
-internal fun PublicKey.sha1Hash(): ByteArray = MessageDigest.getInstance("SHA-1").digest(encoded)
+internal fun PublicKey.sha1Hash(): ByteArray = SHA1.Digest().digest(encoded)

--- a/certificatetransparency/src/test/kotlin/com/babylon/certificatetransparency/internal/utils/PublicKeyExtTest.kt
+++ b/certificatetransparency/src/test/kotlin/com/babylon/certificatetransparency/internal/utils/PublicKeyExtTest.kt
@@ -40,7 +40,7 @@ class PublicKeyExtTest {
         // given a certificate
         val certificate = TestData.loadCertificates(TestData.TEST_CERT)[0]
 
-        // when we hash the public key using SHA256
+        // when we hash the public key using SHA1
         val hash = Base64.toBase64String(certificate.publicKey.sha1Hash())
 
         // then the result matches openssl generated using:


### PR DESCRIPTION
Fixes https://github.com/babylonhealth/certificate-transparency-android/issues/71