### PR TITLE
Keep CertificateTransparencyTrustManager inside proguard consumer file

### DIFF
--- a/certificatetransparency-android/consumer-proguard-rules.pro
+++ b/certificatetransparency-android/consumer-proguard-rules.pro
@@ -87,6 +87,9 @@
 # Ensure chain cleaner classes are kept as they're loaded through reflection
 -keep class com.appmattus.certificatetransparency.chaincleaner.* { *; }
 
+# CertificateTransparencyTrustManager contains methods called through reflection
+-keep class com.appmattus.certificatetransparency.internal.verifier.CertificateTransparencyTrustManager { *; }
+
 
 # Specifically for ProGuard (not needed for R8)
 -dontwarn module-info


### PR DESCRIPTION
This fixes issue: https://github.com/appmattus/certificatetransparency/issues/41

Some methods inside CertificateTransparencyTrustManager are called through reflection, so the class must be kept during obfuscation.