### PR TITLE
Fix invoke call of isSameTrustConfigurationMethod

### DIFF
--- a/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/internal/verifier/CertificateTransparencyTrustManager.kt
+++ b/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/internal/verifier/CertificateTransparencyTrustManager.kt
@@ -110,7 +110,7 @@ internal class CertificateTransparencyTrustManager(
     // Called through reflection by X509TrustManagerExtensions on Android
     @Suppress("unused")
     fun isSameTrustConfiguration(hostname1: String?, hostname2: String?): Boolean {
-        return isSameTrustConfigurationMethod!!.invoke(hostname1, hostname2) as Boolean
+        return isSameTrustConfigurationMethod!!.invoke(delegate, hostname1, hostname2) as Boolean
     }
 
     override fun getAcceptedIssuers(): Array<X509Certificate> = delegate.acceptedIssuers


### PR DESCRIPTION
https://github.com/appmattus/certificatetransparency/issues/46

Just adding the delegate to the `isSameTrustConfigurationMethod` call.