### PR TITLE
Update to latest CT policy

### DIFF
--- a/certificatetransparency/src/main/kotlin/com/appmattus/certificaterevocation/RevocationResult.kt
+++ b/certificatetransparency/src/main/kotlin/com/appmattus/certificaterevocation/RevocationResult.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Appmattus Limited
+ * Copyright 2021-2023 Appmattus Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,16 +22,16 @@ import java.security.cert.X509Certificate
 /**
  * Abstract class providing the results of performing certificate revocation checks
  */
-public sealed class RevocationResult {
+public sealed interface RevocationResult {
     /**
      * Abstract class representing certificate revocation checks passed
      */
-    public sealed class Success : RevocationResult() {
+    public sealed interface Success : RevocationResult {
 
         /**
          * Certificate revocation checks passed
          */
-        public object Trusted : Success() {
+        public object Trusted : Success {
             /**
              * Returns a string representation of the object.
              */
@@ -41,7 +41,7 @@ public sealed class RevocationResult {
         /**
          * Insecure connection so no certificate to check revocation
          */
-        public object InsecureConnection : Success() {
+        public object InsecureConnection : Success {
             /**
              * Returns a string representation of the object.
              */
@@ -52,12 +52,12 @@ public sealed class RevocationResult {
     /**
      * Abstract class representing certificate revocation checks failed
      */
-    public sealed class Failure : RevocationResult() {
+    public sealed interface Failure : RevocationResult {
 
         /**
          * Certificate revocation checks failed as no certificates are present
          */
-        public object NoCertificates : Failure() {
+        public object NoCertificates : Failure {
             /**
              * Returns a string representation of the object.
              */
@@ -67,7 +67,7 @@ public sealed class RevocationResult {
         /**
          * Certificate revocation checks failed as server not trusted
          */
-        public data class CertificateRevoked(val certificate: X509Certificate) : Failure() {
+        public data class CertificateRevoked(val certificate: X509Certificate) : Failure {
             /**
              * Returns a string representation of the object.
              */
@@ -78,7 +78,7 @@ public sealed class RevocationResult {
          * Certificate revocation checks failed due to an unknown [IOException]
          * @property ioException The [IOException] that occurred
          */
-        public data class UnknownIoException(val ioException: IOException) : Failure() {
+        public data class UnknownIoException(val ioException: IOException) : Failure {
             /**
              * Returns a string representation of the object.
              */

--- a/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/CTHostnameVerifierBuilder.kt
+++ b/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/CTHostnameVerifierBuilder.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Appmattus Limited
+ * Copyright 2021-2023 Appmattus Limited
  * Copyright 2019 Babylon Partners Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -67,7 +67,7 @@ public class CTHostnameVerifierBuilder(
 
     /**
      * [CTPolicy] which will verify correct number of SCTs are present
-     * Default: [CTPolicy] which follows rules of https://github.com/chromium/ct-policy/blob/master/ct_policy.md
+     * Default: Follows rules of https://github.com/GoogleChrome/CertificateTransparency/blob/master/ct_policy.md
      */
     public var policy: CTPolicy? = null
         @JvmSynthetic get
@@ -174,7 +174,6 @@ public class CTHostnameVerifierBuilder(
 
     /**
      * [CTPolicy] which will verify correct number of SCTs are present
-     * Default: [CTPolicy] which follows rules of https://github.com/chromium/ct-policy/blob/master/ct_policy.md
      */
     @Suppress("unused")
     public fun setPolicy(policy: CTPolicy): CTHostnameVerifierBuilder = apply { this.policy = policy }

--- a/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/CTInterceptorBuilder.kt
+++ b/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/CTInterceptorBuilder.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Appmattus Limited
+ * Copyright 2021-2023 Appmattus Limited
  * Copyright 2019 Babylon Partners Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -64,7 +64,7 @@ public class CTInterceptorBuilder {
 
     /**
      * [CTPolicy] which will verify correct number of SCTs are present
-     * Default: [CTPolicy] which follows rules of https://github.com/chromium/ct-policy/blob/master/ct_policy.md
+     * Default: Follows rules of https://github.com/GoogleChrome/CertificateTransparency/blob/master/ct_policy.md
      */
     public var policy: CTPolicy? = null
         @JvmSynthetic get
@@ -171,7 +171,6 @@ public class CTInterceptorBuilder {
 
     /**
      * [CTPolicy] which will verify correct number of SCTs are present
-     * Default: [CTPolicy] which follows rules of https://github.com/chromium/ct-policy/blob/master/ct_policy.md
      */
     @Suppress("unused")
     public fun setPolicy(policy: CTPolicy): CTInterceptorBuilder = apply { this.policy = policy }

--- a/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/CTTrustManagerBuilder.kt
+++ b/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/CTTrustManagerBuilder.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Appmattus Limited
+ * Copyright 2021-2023 Appmattus Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ public class CTTrustManagerBuilder(
 
     /**
      * [CTPolicy] which will verify correct number of SCTs are present
-     * Default: [CTPolicy] which follows rules of https://github.com/chromium/ct-policy/blob/master/ct_policy.md
+     * Default: Follows rules of https://github.com/GoogleChrome/CertificateTransparency/blob/master/ct_policy.md
      */
     public var policy: CTPolicy? = null
         @JvmSynthetic get
@@ -149,7 +149,6 @@ public class CTTrustManagerBuilder(
 
     /**
      * [CTPolicy] which will verify correct number of SCTs are present
-     * Default: [CTPolicy] which follows rules of https://github.com/chromium/ct-policy/blob/master/ct_policy.md
      */
     @Suppress("unused")
     public fun setPolicy(policy: CTPolicy): CTTrustManagerBuilder = apply { this.policy = policy }

--- a/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/SctVerificationResult.kt
+++ b/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/SctVerificationResult.kt
@@ -29,7 +29,7 @@ public sealed interface SctVerificationResult {
     /**
      * Signed Certificate Timestamp checks passed
      */
-    public data class Valid(val sct: SignedCertificateTimestamp) : SctVerificationResult {
+    public data class Valid(val sct: SignedCertificateTimestamp, val operator: String) : SctVerificationResult {
         /**
          * Returns a string representation of the object.
          */

--- a/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/SctVerificationResult.kt
+++ b/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/SctVerificationResult.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Appmattus Limited
+ * Copyright 2021-2023 Appmattus Limited
  * Copyright 2019 Babylon Partners Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,14 +20,16 @@
 
 package com.appmattus.certificatetransparency
 
+import com.appmattus.certificatetransparency.internal.verifier.model.SignedCertificateTimestamp
+
 /**
  * Abstract class providing the results of verifying a Signed Certificate Timestamp
  */
-public sealed class SctVerificationResult {
+public sealed interface SctVerificationResult {
     /**
      * Signed Certificate Timestamp checks passed
      */
-    public object Valid : SctVerificationResult() {
+    public data class Valid(val sct: SignedCertificateTimestamp) : SctVerificationResult {
         /**
          * Returns a string representation of the object.
          */
@@ -37,11 +39,11 @@ public sealed class SctVerificationResult {
     /**
      * Abstract class representing Signed Certificate Timestamp checks failed
      */
-    public sealed class Invalid : SctVerificationResult() {
+    public sealed interface Invalid : SctVerificationResult {
         /**
          * Signed Certificate Timestamp checks failed as the signature could not be verified
          */
-        public object FailedVerification : Invalid() {
+        public object FailedVerification : Invalid {
             /**
              * Returns a string representation of the object.
              */
@@ -51,7 +53,7 @@ public sealed class SctVerificationResult {
         /**
          * Signed Certificate Timestamp checks failed as there was no log server we trust in the log-list.json
          */
-        public object NoTrustedLogServerFound : Invalid() {
+        public object NoTrustedLogServerFound : Invalid {
             /**
              * Returns a string representation of the object.
              */
@@ -63,7 +65,7 @@ public sealed class SctVerificationResult {
          * @property timestamp The timestamp of the SCT
          * @property now The time now
          */
-        public data class FutureTimestamp(val timestamp: Long, val now: Long) : Invalid() {
+        public data class FutureTimestamp(val timestamp: Long, val now: Long) : Invalid {
             /**
              * Returns a string representation of the object.
              */
@@ -75,7 +77,7 @@ public sealed class SctVerificationResult {
          * @property timestamp The timestamp of the SCT
          * @property logServerValidUntil The time the log server was valid till
          */
-        public data class LogServerUntrusted(val timestamp: Long, val logServerValidUntil: Long) : Invalid() {
+        public data class LogServerUntrusted(val timestamp: Long, val logServerValidUntil: Long) : Invalid {
             /**
              * Returns a string representation of the object.
              */
@@ -85,12 +87,12 @@ public sealed class SctVerificationResult {
         /**
          * Signed Certificate Timestamp checks failed for an unspecified reason
          */
-        public open class Failed : Invalid()
+        public open class Failed : Invalid
 
         /**
          * Signed Certificate Timestamp checks failed as an [exception] was detected
          */
-        public abstract class FailedWithException : Invalid() {
+        public abstract class FailedWithException : Invalid {
             /**
              * The [exception] that occurred
              */

--- a/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/VerificationResult.kt
+++ b/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/VerificationResult.kt
@@ -126,7 +126,7 @@ public sealed interface VerificationResult {
              * Returns a string representation of the object.
              */
             override fun toString(): String {
-                val trustedScts = scts.values.filterIsInstance<SctVerificationResult.Valid>().distinctBy { it.sct.id }.size
+                val trustedScts = scts.values.filterIsInstance<SctVerificationResult.Valid>().distinctBy { it.operator }.size
                 return "Failure: Too few distinct operators, required $minSctCount, found $trustedScts in ${scts.forDisplay()}"
             }
         }

--- a/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/VerificationResult.kt
+++ b/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/VerificationResult.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Appmattus Limited
+ * Copyright 2021-2023 Appmattus Limited
  * Copyright 2019 Babylon Partners Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,17 +27,17 @@ import java.io.IOException
 /**
  * Abstract class providing the results of performing certificate transparency checks
  */
-public sealed class VerificationResult {
+public sealed interface VerificationResult {
     /**
      * Abstract class representing certificate transparency checks passed
      */
-    public sealed class Success : VerificationResult() {
+    public sealed interface Success : VerificationResult {
 
         /**
          * Certificate transparency checks passed as [host] is not being verified
          * @property host The host certificate transparency is not enabled for
          */
-        public data class DisabledForHost(val host: String) : Success() {
+        public data class DisabledForHost(val host: String) : Success {
             /**
              * Returns a string representation of the object.
              */
@@ -48,7 +48,7 @@ public sealed class VerificationResult {
          * Certificate transparency checks passed with the provided [scts]
          * @property scts Map of logIds to [SctVerificationResult] showing the results of checking each Signed Certificate Timestamp
          */
-        public data class Trusted(val scts: Map<String, SctVerificationResult>) : Success() {
+        public data class Trusted(val scts: Map<String, SctVerificationResult>) : Success {
             /**
              * Returns a string representation of the object.
              */
@@ -56,7 +56,7 @@ public sealed class VerificationResult {
                 "Success: SCT trusted logs ${scts.forDisplay()}"
         }
 
-        public data class InsecureConnection(val host: String) : Success() {
+        public data class InsecureConnection(val host: String) : Success {
             /**
              * Returns a string representation of the object.
              */
@@ -67,12 +67,12 @@ public sealed class VerificationResult {
     /**
      * Abstract class representing certificate transparency checks failed
      */
-    public sealed class Failure : VerificationResult() {
+    public sealed interface Failure : VerificationResult {
 
         /**
          * Certificate transparency checks failed as no certificates are present
          */
-        public object NoCertificates : Failure() {
+        public object NoCertificates : Failure {
             /**
              * Returns a string representation of the object.
              */
@@ -83,7 +83,7 @@ public sealed class VerificationResult {
          * Certificate transparency checks failed as couldn't load list of [LogServer]. This can occur if there are network problems loading
          * the log-list.json or log-list.sig file along with issues with the signature
          */
-        public data class LogServersFailed(val logListResult: LogListResult.Invalid) : Failure() {
+        public data class LogServersFailed(val logListResult: LogListResult.Invalid) : Failure {
             /**
              * Returns a string representation of the object.
              */
@@ -94,7 +94,7 @@ public sealed class VerificationResult {
          * Certificate transparency checks failed as no Signed Certificate Timestamps have been found in the X.509 extensions. This can occur
          * if your server relies on providing SCTs through TLS extensions or OCSP stapling instead.
          */
-        public object NoScts : Failure() {
+        public object NoScts : Failure {
             /**
              * Returns a string representation of the object.
              */
@@ -106,7 +106,7 @@ public sealed class VerificationResult {
          * @property scts Map of logIds to [SctVerificationResult] stating which SCTs passed or failed checks
          * @property minSctCount The number of valid SCTs required for trust to be established
          */
-        public data class TooFewSctsTrusted(val scts: Map<String, SctVerificationResult>, val minSctCount: Int) : Failure() {
+        public data class TooFewSctsTrusted(val scts: Map<String, SctVerificationResult>, val minSctCount: Int) : Failure {
             /**
              * Returns a string representation of the object.
              */
@@ -120,7 +120,7 @@ public sealed class VerificationResult {
          * Certificate transparency checks failed due to an unknown [IOException]
          * @property ioException The [IOException] that occurred
          */
-        public data class UnknownIoException(val ioException: IOException) : Failure() {
+        public data class UnknownIoException(val ioException: IOException) : Failure {
             /**
              * Returns a string representation of the object.
              */

--- a/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/VerificationResult.kt
+++ b/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/VerificationResult.kt
@@ -117,6 +117,21 @@ public sealed interface VerificationResult {
         }
 
         /**
+         * Certificate transparency checks failed as there are not enough Signed Certificate Timestamps with distinct operators
+         * @property scts Map of logIds to [SctVerificationResult] stating which SCTs passed or failed checks
+         * @property minSctCount The number of valid SCTs required for trust to be established
+         */
+        public data class TooFewDistinctOperators(val scts: Map<String, SctVerificationResult>, val minSctCount: Int) : Failure {
+            /**
+             * Returns a string representation of the object.
+             */
+            override fun toString(): String {
+                val trustedScts = scts.values.filterIsInstance<SctVerificationResult.Valid>().distinctBy { it.sct.id }.size
+                return "Failure: Too few distinct operators, required $minSctCount, found $trustedScts in ${scts.forDisplay()}"
+            }
+        }
+
+        /**
          * Certificate transparency checks failed due to an unknown [IOException]
          * @property ioException The [IOException] that occurred
          */

--- a/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/internal/loglist/LogListZipNetworkDataSource.kt
+++ b/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/internal/loglist/LogListZipNetworkDataSource.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Appmattus Limited
+ * Copyright 2021-2023 Appmattus Limited
  * Copyright 2020 Babylon Partners Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -84,9 +84,9 @@ internal class LogListZipNetworkDataSource(
         }
     }
 
-    private sealed class Data {
-        class Valid(val bytes: ByteArray) : Data()
-        class Invalid(val error: RawLogListResult) : Data()
+    private sealed interface Data {
+        class Valid(val bytes: ByteArray) : Data
+        class Invalid(val error: RawLogListResult) : Data
     }
 
     companion object {

--- a/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/internal/loglist/LogServerSignatureResult.kt
+++ b/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/internal/loglist/LogServerSignatureResult.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Appmattus Limited
+ * Copyright 2021-2023 Appmattus Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,25 +21,25 @@ import java.security.InvalidKeyException
 import java.security.NoSuchAlgorithmException
 import java.security.SignatureException
 
-internal sealed class LogServerSignatureResult {
-    object Valid : LogServerSignatureResult() {
+internal sealed interface LogServerSignatureResult {
+    object Valid : LogServerSignatureResult {
         override fun toString() = "Valid signature"
     }
 
-    sealed class Invalid : LogServerSignatureResult() {
-        object SignatureFailed : Invalid() {
+    sealed interface Invalid : LogServerSignatureResult {
+        object SignatureFailed : Invalid {
             override fun toString() = "Invalid signature"
         }
 
-        data class SignatureNotValid(val exception: SignatureException) : Invalid() {
+        data class SignatureNotValid(val exception: SignatureException) : Invalid {
             override fun toString() = "Invalid signature (public key) with ${exception.stringStackTrace()}"
         }
 
-        data class PublicKeyNotValid(val exception: InvalidKeyException) : Invalid() {
+        data class PublicKeyNotValid(val exception: InvalidKeyException) : Invalid {
             override fun toString() = "Invalid signature (public key) with ${exception.stringStackTrace()}"
         }
 
-        data class NoSuchAlgorithm(val exception: NoSuchAlgorithmException) : Invalid() {
+        data class NoSuchAlgorithm(val exception: NoSuchAlgorithmException) : Invalid {
             override fun toString() = "Invalid signature (public key) with ${exception.stringStackTrace()}"
         }
     }

--- a/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/internal/utils/CertificateExt.kt
+++ b/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/internal/utils/CertificateExt.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Appmattus Limited
+ * Copyright 2021-2023 Appmattus Limited
  * Copyright 2019 Babylon Partners Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/internal/utils/PublicKeyExt.kt
+++ b/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/internal/utils/PublicKeyExt.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Appmattus Limited
+ * Copyright 2021-2023 Appmattus Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/internal/utils/PublicKeyFactory.kt
+++ b/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/internal/utils/PublicKeyFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Appmattus Limited
+ * Copyright 2021-2023 Appmattus Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/internal/verifier/CertificateTransparencyTrustManager.kt
+++ b/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/internal/verifier/CertificateTransparencyTrustManager.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Appmattus Limited
+ * Copyright 2021-2023 Appmattus Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/internal/verifier/DefaultPolicy.kt
+++ b/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/internal/verifier/DefaultPolicy.kt
@@ -38,10 +38,10 @@ internal class DefaultPolicy : CTPolicy {
         leafCertificate: X509Certificate,
         sctResults: Map<String, SctVerificationResult>
     ): VerificationResult {
-        val validScts = sctResults.values.filterIsInstance<SctVerificationResult.Valid>().map { it.sct }
+        val validScts = sctResults.values.filterIsInstance<SctVerificationResult.Valid>()
 
         // By default we use the 2022 policy when there are no valid SCTs
-        val issuanceDate = validScts.minOfOrNull { it.timestamp } ?: Long.MAX_VALUE
+        val issuanceDate = validScts.minOfOrNull { it.sct.timestamp } ?: Long.MAX_VALUE
         val use2022policy = issuanceDate >= policyUpdateDate
 
         val before = leafCertificate.notBefore.toInstant().atZone(ZoneOffset.UTC)
@@ -62,7 +62,7 @@ internal class DefaultPolicy : CTPolicy {
 
         return if (validScts.size < minimumValidSignedCertificateTimestamps) {
             VerificationResult.Failure.TooFewSctsTrusted(sctResults, minimumValidSignedCertificateTimestamps)
-        } else if (validScts.distinctBy { it.id }.size < minimumValidSignedCertificateTimestamps) {
+        } else if (validScts.distinctBy { it.operator }.size < minimumValidSignedCertificateTimestamps) {
             VerificationResult.Failure.TooFewDistinctOperators(sctResults, minimumValidSignedCertificateTimestamps)
         } else {
             VerificationResult.Success.Trusted(sctResults)

--- a/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/internal/verifier/DefaultPolicy.kt
+++ b/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/internal/verifier/DefaultPolicy.kt
@@ -38,8 +38,10 @@ internal class DefaultPolicy : CTPolicy {
         leafCertificate: X509Certificate,
         sctResults: Map<String, SctVerificationResult>
     ): VerificationResult {
+        val validScts = sctResults.values.filterIsInstance<SctVerificationResult.Valid>().map { it.sct }
+
         // By default we use the 2022 policy when there are no valid SCTs
-        val issuanceDate = sctResults.values.filterIsInstance<SctVerificationResult.Valid>().minOfOrNull { it.sct.timestamp } ?: Long.MAX_VALUE
+        val issuanceDate = validScts.minOfOrNull { it.timestamp } ?: Long.MAX_VALUE
         val use2022policy = issuanceDate >= policyUpdateDate
 
         val before = leafCertificate.notBefore.toInstant().atZone(ZoneOffset.UTC)
@@ -58,8 +60,10 @@ internal class DefaultPolicy : CTPolicy {
             }
         }
 
-        return if (sctResults.count { it.value is SctVerificationResult.Valid } < minimumValidSignedCertificateTimestamps) {
+        return if (validScts.size < minimumValidSignedCertificateTimestamps) {
             VerificationResult.Failure.TooFewSctsTrusted(sctResults, minimumValidSignedCertificateTimestamps)
+        } else if (validScts.distinctBy { it.id }.size < minimumValidSignedCertificateTimestamps) {
+            VerificationResult.Failure.TooFewDistinctOperators(sctResults, minimumValidSignedCertificateTimestamps)
         } else {
             VerificationResult.Success.Trusted(sctResults)
         }

--- a/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/internal/verifier/LogSignatureVerifier.kt
+++ b/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/internal/verifier/LogSignatureVerifier.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Appmattus Limited
+ * Copyright 2021-2023 Appmattus Limited
  * Copyright 2019 Babylon Partners Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -225,7 +225,7 @@ internal class LogSignatureVerifier(private val logServer: LogServer) : Signatur
                 update(toVerify)
             }.verify(sct.signature.signature)
 
-            if (result) SctVerificationResult.Valid else SctVerificationResult.Invalid.FailedVerification
+            if (result) SctVerificationResult.Valid(sct) else SctVerificationResult.Invalid.FailedVerification
         } catch (e: SignatureException) {
             SignatureNotValid(e)
         } catch (e: InvalidKeyException) {

--- a/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/internal/verifier/LogSignatureVerifier.kt
+++ b/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/internal/verifier/LogSignatureVerifier.kt
@@ -225,7 +225,8 @@ internal class LogSignatureVerifier(private val logServer: LogServer) : Signatur
                 update(toVerify)
             }.verify(sct.signature.signature)
 
-            if (result) SctVerificationResult.Valid(sct) else SctVerificationResult.Invalid.FailedVerification
+            val operator = logServer.operatorAt(sct.timestamp)
+            if (result) SctVerificationResult.Valid(sct, operator) else SctVerificationResult.Invalid.FailedVerification
         } catch (e: SignatureException) {
             SignatureNotValid(e)
         } catch (e: InvalidKeyException) {

--- a/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/internal/verifier/SignatureVerifier.kt
+++ b/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/internal/verifier/SignatureVerifier.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Appmattus Limited
+ * Copyright 2021-2023 Appmattus Limited
  * Copyright 2019 Babylon Partners Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/internal/verifier/model/IssuerInformation.kt
+++ b/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/internal/verifier/model/IssuerInformation.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Appmattus Limited
+ * Copyright 2021-2023 Appmattus Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/internal/verifier/model/LogId.kt
+++ b/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/internal/verifier/model/LogId.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Appmattus Limited
+ * Copyright 2021-2023 Appmattus Limited
  * Copyright 2019 Babylon Partners Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/loglist/LogListResult.kt
+++ b/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/loglist/LogListResult.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Appmattus Limited
+ * Copyright 2021-2023 Appmattus Limited
  * Copyright 2019 Babylon Partners Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,14 +20,14 @@
 
 package com.appmattus.certificatetransparency.loglist
 
-public sealed class LogListResult {
+public sealed interface LogListResult {
     /**
      * Class representing log list loading successful
      */
-    public data class Valid(val servers: List<LogServer>) : LogListResult()
+    public data class Valid(val servers: List<LogServer>) : LogListResult
 
     /**
      * Abstract class representing log list loading failed
      */
-    public open class Invalid : LogListResult()
+    public open class Invalid : LogListResult
 }

--- a/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/loglist/LogServer.kt
+++ b/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/loglist/LogServer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Appmattus Limited
+ * Copyright 2021-2023 Appmattus Limited
  * Copyright 2019 Babylon Partners Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,12 +30,23 @@ import java.security.PublicKey
  */
 public data class LogServer(
     val key: PublicKey,
-    val validUntil: Long? = null
+    val validUntil: Long? = null,
+    val operator: String,
+    val previousOperators: List<PreviousOperator>
 ) {
     /**
      * The log servers id. A SHA-256 hash of the log servers [PublicKey]
      */
     val id: ByteArray = key.sha256Hash()
+
+    public fun operatorAt(timestamp: Long): String {
+        previousOperators.sortedBy { it.endDate }.forEach {
+            if (timestamp < it.endDate) return it.name
+        }
+        // Either the log has only ever had one operator, or the timestamp is after
+        // the last operator change.
+        return operator
+    }
 
     public companion object
 }

--- a/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/loglist/PreviousOperator.kt
+++ b/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/loglist/PreviousOperator.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023 Appmattus Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.appmattus.certificatetransparency.loglist
+
+public data class PreviousOperator(val name: String, val endDate: Long) {
+    public companion object
+}

--- a/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/loglist/RawLogListResult.kt
+++ b/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/loglist/RawLogListResult.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Appmattus Limited
+ * Copyright 2021-2023 Appmattus Limited
  * Copyright 2019 Babylon Partners Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +23,7 @@ package com.appmattus.certificatetransparency.loglist
 /**
  * Class representing the raw log list data
  */
-public sealed class RawLogListResult {
+public sealed interface RawLogListResult {
 
     /**
      * Class representing raw log list data loading successfully
@@ -31,7 +31,7 @@ public sealed class RawLogListResult {
     public data class Success(
         val logList: ByteArray,
         val signature: ByteArray
-    ) : RawLogListResult() {
+    ) : RawLogListResult {
 
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
@@ -55,5 +55,5 @@ public sealed class RawLogListResult {
     /**
      * Class representing raw log list data loading failed
      */
-    public open class Failure : RawLogListResult()
+    public open class Failure : RawLogListResult
 }

--- a/certificatetransparency/src/test/kotlin/com/appmattus/certificatetransparency/internal/verifier/DefaultPolicyTest.kt
+++ b/certificatetransparency/src/test/kotlin/com/appmattus/certificatetransparency/internal/verifier/DefaultPolicyTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Appmattus Limited
+ * Copyright 2021-2023 Appmattus Limited
  * Copyright 2019 Babylon Partners Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,6 +22,9 @@ package com.appmattus.certificatetransparency.internal.verifier
 
 import com.appmattus.certificatetransparency.SctVerificationResult
 import com.appmattus.certificatetransparency.VerificationResult
+import com.appmattus.certificatetransparency.internal.verifier.model.DigitallySigned
+import com.appmattus.certificatetransparency.internal.verifier.model.LogId
+import com.appmattus.certificatetransparency.internal.verifier.model.SignedCertificateTimestamp
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -32,54 +35,108 @@ import org.mockito.kotlin.whenever
 import java.security.cert.X509Certificate
 import java.util.Calendar
 import java.util.Date
-import java.util.Random
+import java.util.TimeZone
+import java.util.UUID
+import kotlin.random.Random
 
 @RunWith(Parameterized::class)
 internal class DefaultPolicyTest(
     @Suppress("unused") private val description: String,
     private val start: Date,
     private val end: Date,
-    private val sctsRequired: Int
+    private val oldPolicySctsRequired: Int,
+    private val newPolicySctsRequired: Int
 ) {
 
     @Test
-    fun fewerSctsThanRequiredReturnsFailure() {
+    fun fewerSctsThanRequiredReturnsFailureOldPolicy() {
         // given a certificate with start and end date specified
         val certificate: X509Certificate = mock()
         whenever(certificate.notBefore).thenReturn(start)
         whenever(certificate.notAfter).thenReturn(end)
 
         // and fewer SCTs than required
-        val scts = mutableMapOf<String, SctVerificationResult>()
-        for (i in 0 until Random().nextInt(sctsRequired)) {
-            scts[i.toString()] = SctVerificationResult.Valid
-        }
-        for (i in 0 until 10) {
-            scts[(i + 100).toString()] = SctVerificationResult.Invalid.FailedVerification
-        }
+        val scts = buildList {
+            // we ensure there is at least one valid SCT so the old policy is selected
+            for (i in 0 until Random.nextInt(1, oldPolicySctsRequired)) {
+                add(SctVerificationResult.Valid(oldPolicySct))
+            }
+            for (i in 0 until 10) {
+                add(SctVerificationResult.Invalid.FailedVerification)
+            }
+        }.shuffled().associateBy { UUID.randomUUID().toString() }
 
         // when we execute the default policy
         val result = DefaultPolicy().policyVerificationResult(certificate, scts) as VerificationResult.Failure.TooFewSctsTrusted
 
         // then the correct number of SCTs are required
-        assertEquals(sctsRequired, result.minSctCount)
+        assertEquals(oldPolicySctsRequired, result.minSctCount)
     }
 
     @Test
-    fun correctNumberOfSctsReturnsSuccessTrusted() {
+    fun fewerSctsThanRequiredReturnsFailureNewPolicy() {
+        // given a certificate with start and end date specified
+        val certificate: X509Certificate = mock()
+        whenever(certificate.notBefore).thenReturn(start)
+        whenever(certificate.notAfter).thenReturn(end)
+
+        // and fewer SCTs than required
+        val scts = buildList {
+            for (i in 0 until Random.nextInt(0, newPolicySctsRequired)) {
+                add(SctVerificationResult.Valid(newPolicySct))
+            }
+            for (i in 0 until 10) {
+                add(SctVerificationResult.Invalid.FailedVerification)
+            }
+        }.shuffled().associateBy { UUID.randomUUID().toString() }
+
+        // when we execute the default policy
+        val result = DefaultPolicy().policyVerificationResult(certificate, scts) as VerificationResult.Failure.TooFewSctsTrusted
+
+        // then the correct number of SCTs are required
+        assertEquals(newPolicySctsRequired, result.minSctCount)
+    }
+
+    @Test
+    fun correctNumberOfSctsReturnsSuccessTrustedOldPolicy() {
         // given a certificate with start and end date specified
         val certificate: X509Certificate = mock()
         whenever(certificate.notBefore).thenReturn(start)
         whenever(certificate.notAfter).thenReturn(end)
 
         // and correct number of trusted SCTs present
-        val scts = mutableMapOf<String, SctVerificationResult>()
-        for (i in 0 until sctsRequired) {
-            scts[i.toString()] = SctVerificationResult.Valid
-        }
-        for (i in 0 until 10) {
-            scts[(i + 100).toString()] = SctVerificationResult.Invalid.FailedVerification
-        }
+        val scts = buildList {
+            for (i in 0 until oldPolicySctsRequired) {
+                add(SctVerificationResult.Valid(oldPolicySct))
+            }
+            for (i in 0 until 10) {
+                add(SctVerificationResult.Invalid.FailedVerification)
+            }
+        }.shuffled().associateBy { UUID.randomUUID().toString() }
+
+        // when we execute the default policy
+        val result = DefaultPolicy().policyVerificationResult(certificate, scts)
+
+        // then the policy passes
+        assertTrue(result is VerificationResult.Success.Trusted)
+    }
+
+    @Test
+    fun correctNumberOfSctsReturnsSuccessTrustedNewPolicy() {
+        // given a certificate with start and end date specified
+        val certificate: X509Certificate = mock()
+        whenever(certificate.notBefore).thenReturn(start)
+        whenever(certificate.notAfter).thenReturn(end)
+
+        // and correct number of trusted SCTs present
+        val scts = buildList {
+            for (i in 0 until newPolicySctsRequired) {
+                add(SctVerificationResult.Valid(newPolicySct))
+            }
+            for (i in 0 until 10) {
+                add(SctVerificationResult.Invalid.FailedVerification)
+            }
+        }.shuffled().associateBy { UUID.randomUUID().toString() }
 
         // when we execute the default policy
         val result = DefaultPolicy().policyVerificationResult(certificate, scts)
@@ -100,19 +157,41 @@ internal class DefaultPolicyTest(
                 set(Calendar.MINUTE, minute)
                 set(Calendar.SECOND, second)
                 set(Calendar.MILLISECOND, milliseconds)
+                timeZone = TimeZone.getTimeZone("UTC")
             }.time
 
         @JvmStatic
         @Parameterized.Parameters(name = "{0} ({1} -> {2})")
         fun data() = arrayOf(
-            arrayOf("Cert valid for -14 months (nonsensical), needs 2 SCTs", date(2016, 6, 6, 11, 25, 0, 0), date(2015, 3, 25, 11, 25, 0, 0), 2),
-            arrayOf("Cert valid for 14 months, needs 2 SCTs", date(2015, 3, 25, 11, 25, 0, 0), date(2016, 6, 6, 11, 25, 0, 0), 2),
-            arrayOf("Cert valid for exactly 15 months, needs 3 SCTs", date(2015, 3, 25, 11, 25, 0, 0), date(2016, 6, 25, 11, 25, 0, 0), 3),
-            arrayOf("Cert valid for over 15 months, needs 3 SCTs", date(2015, 3, 25, 11, 25, 0, 0), date(2016, 6, 27, 11, 25, 0, 0), 3),
-            arrayOf("Cert valid for exactly 27 months, needs 3 SCTs", date(2015, 3, 25, 11, 25, 0, 0), date(2017, 6, 25, 11, 25, 0, 0), 3),
-            arrayOf("Cert valid for over 27 months, needs 4 SCTs", date(2015, 3, 25, 11, 25, 0, 0), date(2017, 6, 28, 11, 25, 0, 0), 4),
-            arrayOf("Cert valid for exactly 39 months, needs 4 SCTs", date(2015, 3, 25, 11, 25, 0, 0), date(2018, 6, 25, 11, 25, 0, 0), 4),
-            arrayOf("Cert valid for over 39 months, needs 5 SCTs", date(2015, 3, 25, 11, 25, 0, 0), date(2018, 6, 27, 11, 25, 0, 0), 5)
+            arrayOf(
+                "Cert valid for -14 months (nonsensical), needs 2 SCTs",
+                date(2016, 6, 6, 11, 25, 0, 0),
+                date(2015, 3, 25, 11, 25, 0, 0),
+                2,
+                2
+            ),
+            arrayOf("Cert valid for 14 months, needs 2 SCTs", date(2015, 3, 25, 11, 25, 0, 0), date(2016, 6, 6, 11, 25, 0, 0), 2, 3),
+            arrayOf("Cert valid for exactly 15 months, needs 3 SCTs", date(2015, 3, 25, 11, 25, 0, 0), date(2016, 6, 25, 11, 25, 0, 0), 3, 3),
+            arrayOf("Cert valid for over 15 months, needs 3 SCTs", date(2015, 3, 25, 11, 25, 0, 0), date(2016, 6, 27, 11, 25, 0, 0), 3, 3),
+            arrayOf("Cert valid for exactly 27 months, needs 3 SCTs", date(2015, 3, 25, 11, 25, 0, 0), date(2017, 6, 25, 11, 25, 0, 0), 3, 3),
+            arrayOf("Cert valid for over 27 months, needs 4 SCTs", date(2015, 3, 25, 11, 25, 0, 0), date(2017, 6, 28, 11, 25, 0, 0), 4, 3),
+            arrayOf("Cert valid for exactly 39 months, needs 4 SCTs", date(2015, 3, 25, 11, 25, 0, 0), date(2018, 6, 25, 11, 25, 0, 0), 4, 3),
+            arrayOf("Cert valid for over 39 months, needs 5 SCTs", date(2015, 3, 25, 11, 25, 0, 0), date(2018, 6, 27, 11, 25, 0, 0), 5, 3)
+        )
+
+        private val oldPolicySct = SignedCertificateTimestamp(
+            id = LogId(byteArrayOf()),
+            timestamp = 0,
+            extensions = byteArrayOf(),
+            signature = DigitallySigned(signature = byteArrayOf())
+        )
+
+        private val newPolicySct = SignedCertificateTimestamp(
+            id = LogId(byteArrayOf()),
+            // 15 April 2022
+            timestamp = 1649980800000,
+            extensions = byteArrayOf(),
+            signature = DigitallySigned(signature = byteArrayOf())
         )
     }
 }

--- a/certificatetransparency/src/test/kotlin/com/appmattus/certificatetransparency/internal/verifier/DefaultPolicyTest.kt
+++ b/certificatetransparency/src/test/kotlin/com/appmattus/certificatetransparency/internal/verifier/DefaultPolicyTest.kt
@@ -55,11 +55,11 @@ internal class DefaultPolicyTest {
             whenever(certificate.notBefore).thenReturn(start)
             whenever(certificate.notAfter).thenReturn(end)
 
-            // and correct number of trusted SCTs present with duplicate log ids
+            // and correct number of trusted SCTs present with duplicate operator
             val scts = buildList {
                 repeat(3) {
-                    // ids use different byte arrays but the same content
-                    add(SctVerificationResult.Valid(newPolicySct.copy(id = LogId(byteArrayOf(1, 2, 3, 4, 5)))))
+                    // operator has the same value
+                    add(SctVerificationResult.Valid(newPolicySct, "12345"))
                 }
                 repeat(5) {
                     add(SctVerificationResult.Invalid.FailedVerification)
@@ -84,10 +84,10 @@ internal class DefaultPolicyTest {
             whenever(certificate.notBefore).thenReturn(start)
             whenever(certificate.notAfter).thenReturn(end)
 
-            // and correct number of trusted SCTs present with unique log ids
+            // and correct number of trusted SCTs present with unique operator
             val scts = buildList {
                 repeat(3) {
-                    add(SctVerificationResult.Valid(newPolicySct))
+                    add(SctVerificationResult.Valid(newPolicySct, UUID.randomUUID().toString()))
                 }
                 repeat(5) {
                     add(SctVerificationResult.Invalid.FailedVerification)
@@ -122,7 +122,7 @@ internal class DefaultPolicyTest {
             val scts = buildList {
                 // we ensure there is at least one valid SCT so the old policy is selected
                 repeat(Random.nextInt(1, oldPolicySctsRequired)) {
-                    add(SctVerificationResult.Valid(oldPolicySct))
+                    add(SctVerificationResult.Valid(oldPolicySct, UUID.randomUUID().toString()))
                 }
                 repeat(10) {
                     add(SctVerificationResult.Invalid.FailedVerification)
@@ -146,7 +146,7 @@ internal class DefaultPolicyTest {
             // and fewer SCTs than required
             val scts = buildList {
                 repeat(Random.nextInt(0, newPolicySctsRequired)) {
-                    add(SctVerificationResult.Valid(newPolicySct))
+                    add(SctVerificationResult.Valid(newPolicySct, UUID.randomUUID().toString()))
                 }
                 repeat(10) {
                     add(SctVerificationResult.Invalid.FailedVerification)
@@ -170,7 +170,7 @@ internal class DefaultPolicyTest {
             // and correct number of trusted SCTs present
             val scts = buildList {
                 repeat(oldPolicySctsRequired) {
-                    add(SctVerificationResult.Valid(oldPolicySct))
+                    add(SctVerificationResult.Valid(oldPolicySct, UUID.randomUUID().toString()))
                 }
                 repeat(10) {
                     add(SctVerificationResult.Invalid.FailedVerification)
@@ -194,7 +194,7 @@ internal class DefaultPolicyTest {
             // and correct number of trusted SCTs present
             val scts = buildList {
                 repeat(newPolicySctsRequired) {
-                    add(SctVerificationResult.Valid(newPolicySct))
+                    add(SctVerificationResult.Valid(newPolicySct, UUID.randomUUID().toString()))
                 }
                 repeat(10) {
                     add(SctVerificationResult.Invalid.FailedVerification)

--- a/certificatetransparency/src/test/kotlin/com/appmattus/certificatetransparency/internal/verifier/LogSignatureVerifierTest.kt
+++ b/certificatetransparency/src/test/kotlin/com/appmattus/certificatetransparency/internal/verifier/LogSignatureVerifierTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Appmattus Limited
+ * Copyright 2021-2023 Appmattus Limited
  * Copyright 2019 Babylon Partners Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -279,6 +279,6 @@ internal class LogSignatureVerifierTest {
      */
     private fun LogServer.Companion.fromKeyFile(pemKeyFilePath: String): LogServer {
         val logPublicKey = File(pemKeyFilePath).readPemFile()
-        return LogServer(logPublicKey)
+        return LogServer(logPublicKey, operator = "", previousOperators = emptyList())
     }
 }

--- a/certificatetransparency/src/test/kotlin/com/appmattus/certificatetransparency/utils/FileExt.kt
+++ b/certificatetransparency/src/test/kotlin/com/appmattus/certificatetransparency/utils/FileExt.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Appmattus Limited
+ * Copyright 2021-2023 Appmattus Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/certificatetransparency/src/test/kotlin/com/appmattus/certificatetransparency/utils/LogListDataSourceTestFactory.kt
+++ b/certificatetransparency/src/test/kotlin/com/appmattus/certificatetransparency/utils/LogListDataSourceTestFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Appmattus Limited
+ * Copyright 2021-2023 Appmattus Limited
  * Copyright 2020 Babylon Partners Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,7 +21,6 @@
 package com.appmattus.certificatetransparency.utils
 
 import com.appmattus.certificatetransparency.datasource.DataSource
-import com.appmattus.certificatetransparency.internal.loglist.model.v3.Log
 import com.appmattus.certificatetransparency.internal.loglist.model.v3.LogListV3
 import com.appmattus.certificatetransparency.internal.utils.Base64
 import com.appmattus.certificatetransparency.internal.utils.PublicKeyFactory
@@ -39,13 +38,12 @@ internal object LogListDataSourceTestFactory {
     val logListDataSource: DataSource<LogListResult> by lazy {
         // Collection of CT logs that are trusted from https://www.gstatic.com/ct/log_list/v3/log_list.json
         val json = TestData.file(TestData.TEST_LOG_LIST_JSON).readText()
-        val trustedLogKeys = Json.decodeFromString(LogListV3.serializer(), json).operators.flatMap { it.logs.map(Log::key) }
 
-        val list = LogListResult.Valid(
-            trustedLogKeys.map { Base64.decode(it) }.map {
-                LogServer(PublicKeyFactory.fromByteArray(it))
+        val list = Json.decodeFromString(LogListV3.serializer(), json).operators.map { operator ->
+            operator.logs.map {
+                LogServer(PublicKeyFactory.fromByteArray(Base64.decode(it.key)), operator = operator.name, previousOperators = emptyList())
             }
-        )
+        }.flatten().let(LogListResult::Valid)
 
         object : DataSource<LogListResult> {
             override suspend fun get() = list

--- a/sampleapp/src/main/java/com/appmattus/certificatetransparency/sampleapp/examples/State.kt
+++ b/sampleapp/src/main/java/com/appmattus/certificatetransparency/sampleapp/examples/State.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Appmattus Limited
+ * Copyright 2021-2023 Appmattus Limited
  * Copyright 2019 Babylon Partners Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,10 +28,10 @@ data class State(
     val message: Message? = null
 ) {
 
-    sealed class Message {
-        abstract val text: String
+    sealed interface Message {
+        val text: String
 
-        data class Success(override val text: String) : Message()
-        data class Failure(override val text: String) : Message()
+        data class Success(override val text: String) : Message
+        data class Failure(override val text: String) : Message
     }
 }


### PR DESCRIPTION
Based on https://github.com/GoogleChrome/CertificateTransparency/blob/master/ct_policy.md

For certificates issued after 15 April 2022 fewer SCTs are required with 2 if certificate age < 180 dates and 3 if >= 180 days

The default policy now also implements distinct operator checks which uses the v3 files previous operator entries where appropriate

Fixes #53 