### PR TITLE
Ensure SSL cannot be used to retrieve log-list.json

### DIFF
--- a/certificatetransparency/src/test/kotlin/com/appmattus/certificatetransparency/loglist/LogListDataSourceFactoryTest.kt
+++ b/certificatetransparency/src/test/kotlin/com/appmattus/certificatetransparency/loglist/LogListDataSourceFactoryTest.kt
@@ -113,7 +113,7 @@ public class LogListDataSourceFactoryTest {
             val dataSource =
                 LogListDataSourceFactory.createDataSource(
                     logListService = logListService,
-                    now = { Instant.ofEpochMilli(1000000) },
+                    now = { Instant.ofEpochMilli(1000000) }
                 )
             val result = dataSource.get()
 

--- a/certificatetransparency/src/test/kotlin/com/appmattus/certificatetransparency/loglist/LogListDataSourceFactoryTest.kt
+++ b/certificatetransparency/src/test/kotlin/com/appmattus/certificatetransparency/loglist/LogListDataSourceFactoryTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 Appmattus Limited
+ * Copyright 2021-2024 Appmattus Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/certificatetransparency/src/test/kotlin/com/appmattus/certificatetransparency/loglist/LogListDataSourceFactoryTest.kt
+++ b/certificatetransparency/src/test/kotlin/com/appmattus/certificatetransparency/loglist/LogListDataSourceFactoryTest.kt
@@ -20,6 +20,7 @@ import com.appmattus.certificatetransparency.internal.loglist.ResourcesCache
 import com.appmattus.certificatetransparency.utils.TestData
 import com.appmattus.certificatetransparency.utils.assertIsA
 import kotlinx.coroutines.runBlocking
+import okhttp3.ConnectionSpec
 import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -49,8 +50,10 @@ public class LogListDataSourceFactoryTest {
                 val response = when (request.path) {
                     "/log_list.json" -> MockResponse().setResponseCode(200)
                         .setBody(Buffer().write(TestData.file(TestData.TEST_LOG_LIST_JSON).readBytes()))
+
                     "/log_list.sig" -> MockResponse().setResponseCode(200)
                         .setBody(Buffer().write(TestData.file(TestData.TEST_LOG_LIST_SIG).readBytes()))
+
                     "/log_list.zip" -> MockResponse().setResponseCode(200)
                         .setBody(Buffer().write(TestData.file(TestData.TEST_LOG_LIST_ZIP).readBytes()))
 
@@ -79,7 +82,8 @@ public class LogListDataSourceFactoryTest {
                 configuration = { setBodyDelay(5, TimeUnit.SECONDS) }
                 val logListService = LogListDataSourceFactory.createLogListService(
                     baseUrl = baseUrl.toString(),
-                    networkTimeoutSeconds = 1
+                    networkTimeoutSeconds = 1,
+                    connectionSpec = ConnectionSpec.CLEARTEXT
                 )
                 val dataSource = LogListDataSourceFactory.createDataSource(logListService = logListService)
                 // And the resources cache has no data
@@ -100,13 +104,16 @@ public class LogListDataSourceFactoryTest {
     public fun successReturnsValid() {
         runBlocking {
             // Given a default log list service
-            val logListService = LogListDataSourceFactory.createLogListService(baseUrl = baseUrl.toString())
+            val logListService = LogListDataSourceFactory.createLogListService(
+                baseUrl = baseUrl.toString(),
+                connectionSpec = ConnectionSpec.CLEARTEXT
+            )
 
             // When we request the log list
             val dataSource =
                 LogListDataSourceFactory.createDataSource(
                     logListService = logListService,
-                    now = { Instant.ofEpochMilli(1000000) }
+                    now = { Instant.ofEpochMilli(1000000) },
                 )
             val result = dataSource.get()
 
@@ -128,7 +135,8 @@ public class LogListDataSourceFactoryTest {
                 }
                 val logListService = LogListDataSourceFactory.createLogListService(
                     baseUrl = baseUrl.toString(),
-                    networkTimeoutSeconds = 1
+                    networkTimeoutSeconds = 1,
+                    connectionSpec = ConnectionSpec.CLEARTEXT
                 )
                 val dataSource = LogListDataSourceFactory.createDataSource(logListService = logListService)
                 // And the resources cache has no data


### PR DESCRIPTION
Fixes #104

SSLContext is mis-configured to allow SSLv3 protocol. This updates the code to only allow TLSv1.2 or TLSv1.3 by default.