### PR TITLE
We should keep logs values but simply let pass if empty

### DIFF
--- a/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/internal/loglist/model/v3/Operator.kt
+++ b/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/internal/loglist/model/v3/Operator.kt
@@ -26,14 +26,20 @@ import kotlinx.serialization.Serializable
 /**
  * @property name Name of this log operator
  * @property email CT log operator email addresses. The log operator can be contacted using any of these email addresses. (format: email)
+ * @property logs Details of Certificate Transparency logs run by this operator.
+ * @property tiledLogs Details of tiled Certificate Transparency logs run by this operator.
  */
 @Serializable
 internal data class Operator(
     @SerialName("name") val name: String,
     @SerialName("email") val email: List<String>,
+    @SerialName("logs") val logs: List<Log> = emptyList(),
+    @SerialName("tiled_logs") val tiledLogs: List<Log> = emptyList()
 ) {
     init {
         require(name.isNotEmpty())
         require(email.isNotEmpty())
+        // Note: Removed requirement for logs.isNotEmpty() || tiledLogs.isNotEmpty()
+        // to handle cases where operators have empty logs arrays in the JSON
     }
 }

--- a/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/internal/loglist/model/v3/Operator.kt
+++ b/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/internal/loglist/model/v3/Operator.kt
@@ -27,16 +27,18 @@ import kotlinx.serialization.Serializable
  * @property name Name of this log operator
  * @property email CT log operator email addresses. The log operator can be contacted using any of these email addresses. (format: email)
  * @property logs Details of Certificate Transparency logs run by this operator.
+ * @property tiledLogs Details of tiled Certificate Transparency logs run by this operator.
  */
 @Serializable
 internal data class Operator(
     @SerialName("name") val name: String,
     @SerialName("email") val email: List<String>,
-    @SerialName("logs") val logs: List<Log>
+    @SerialName("logs") val logs: List<Log>,
+    @SerialName("tiled_logs") val tiledLogs: List<Log> = emptyList()
 ) {
     init {
         require(name.isNotEmpty())
         require(email.isNotEmpty())
-        require(logs.isNotEmpty())
+        require(logs.isNotEmpty() || tiledLogs.isNotEmpty())
     }
 }

--- a/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/internal/loglist/model/v3/Operator.kt
+++ b/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/internal/loglist/model/v3/Operator.kt
@@ -26,19 +26,14 @@ import kotlinx.serialization.Serializable
 /**
  * @property name Name of this log operator
  * @property email CT log operator email addresses. The log operator can be contacted using any of these email addresses. (format: email)
- * @property logs Details of Certificate Transparency logs run by this operator.
- * @property tiledLogs Details of tiled Certificate Transparency logs run by this operator.
  */
 @Serializable
 internal data class Operator(
     @SerialName("name") val name: String,
     @SerialName("email") val email: List<String>,
-    @SerialName("logs") val logs: List<Log>,
-    @SerialName("tiled_logs") val tiledLogs: List<Log> = emptyList()
 ) {
     init {
         require(name.isNotEmpty())
         require(email.isNotEmpty())
-        require(logs.isNotEmpty() || tiledLogs.isNotEmpty())
     }
 }


### PR DESCRIPTION
Safer than previous PR: https://github.com/1debit/certificatetransparency/pull/1

Keep the logs property but make it optional: @SerialName("logs") val logs: List<Log> = emptyList()
Remove the validation requirement that causes the crash
Keep the tiledLogs property as it was likely also intended for future use
Remove only the problematic validation: require(logs.isNotEmpty() || tiledLogs.isNotEmpty())

Log values used here: https://github.com/1debit/certificatetransparency/blob/2c289a3e0733b68e33db97d74e0321874fb7d3e8/certificatetransparency/src/main/kotlin/com/appmattus/certificatetransparency/internal/loglist/parser/LogListJsonParserV3.kt#L51