### PR TITLE
README: Correct reference to Threat Dragon 🐉

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ kid in town is **[certificate transparency](docs/what-is-certificate-transparenc
 
 We are open about the security of our library and provide a threat model in the
 [source code](ThreatDragonModels/), created using
-[OWASP Threat Dragon](https://threatdragon.org). If you feel there is something
+[OWASP Threat Dragon](https://owasp.org/www-project-threat-dragon/). If you feel there is something
 we have missed please reach out so we can keep this up to date.
 
 The source code and dependencies are continuously scanned with


### PR DESCRIPTION
The documentation refers to OWASP Threat Dragon but links to what seems to be an unrelated (or since re-registered domain) instead of the OWASP project. 